### PR TITLE
fix: groom all uses of cmd.Print*

### DIFF
--- a/client/keys/migrate.go
+++ b/client/keys/migrate.go
@@ -87,7 +87,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(oldKeys) == 0 {
-		cmd.Print("Migration Aborted: no keys to migrate")
+		cmd.PrintErrln("Migration Aborted: no keys to migrate")
 		return nil
 	}
 
@@ -136,7 +136,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	cmd.Print("Migration Complete")
+	cmd.PrintErrln("Migration Complete")
 
 	return err
 }

--- a/x/auth/client/cli/validate_sigs.go
+++ b/x/auth/client/cli/validate_sigs.go
@@ -101,7 +101,7 @@ func printAndValidateSigs(
 		if !offline && success {
 			accNum, accSeq, err := clientCtx.AccountRetriever.GetAccountNumberSequence(clientCtx, sigAddr)
 			if err != nil {
-				cmd.Printf("failed to get account: %s\n", sigAddr)
+				cmd.PrintErrf("failed to get account: %s\n", sigAddr)
 				return false
 			}
 


### PR DESCRIPTION
I went through and audited all uses of `cmd.Print*` to see if they were printing to the wrong place (parsable output to stderr, or error messages to stdout).

I hope you can use this to help land cosmos/cosmos-sdk/#8628

Thanks for your work!
